### PR TITLE
chore(devops): fix Azure Pipelines builds

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -66,6 +66,7 @@ steps:
 
 - task: Npm@1
   displayName: 'Install npm package dev dependencies'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   inputs:
     command: custom
     workingDir: '$(npmPackageDirectory)'
@@ -76,6 +77,7 @@ steps:
 
 - powershell: npx semantic-release
   displayName: 'Run semantic-release'
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   workingDirectory: '$(npmPackageDirectory)'
   env:
     GITHUB_TOKEN: $(GITHUB_TOKEN)

--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -3,11 +3,10 @@ pool:
 
 variables:
   - group: Build
+  - group: Publish
   - group: Bot as git and GitHub user
   - name: solution
     value: '**/*.sln'
-  - name: feedId
-    value: '6d99db17-610d-48e5-aec8-9772c69dc2c2'
   - name: npmPackageDirectory
     value: '$(System.DefaultWorkingDirectory)\Sources\UnityPackaging\bin\Release'
 
@@ -52,7 +51,7 @@ steps:
   displayName: 'NuGet restore'
   inputs:
     restoreSolution: '$(solution)'
-    vstsFeed: '$(feedId)'
+    vstsFeed: '$(Azure.FeedId)'
 
 - task: VSBuild@1
   displayName: 'Build solution'
@@ -73,7 +72,7 @@ steps:
     verbose: false
     customCommand: 'install --only=dev'
     customRegistry: useFeed
-    customFeed: '$(feedId)'
+    customFeed: '$(Azure.FeedId)'
 
 - powershell: npx semantic-release
   displayName: 'Run semantic-release'

--- a/Sources/UnityPackaging/Package/package.json
+++ b/Sources/UnityPackaging/Package/package.json
@@ -27,7 +27,6 @@
         "@semantic-release/commit-analyzer": "^7.0.0-beta.1",
         "@semantic-release/release-notes-generator": "^7.1.4",
         "@semantic-release/changelog": "^3.0.1",
-        "@semantic-release/exec": "^3.4.0-beta.1",
         "@semantic-release/git": "^7.1.0-beta.1",
         "@semantic-release/npm": "^5.2.0-beta.3",
         "@semantic-release/github": "^5.3.0-beta.3"
@@ -110,12 +109,6 @@
                             "label": "Unity Package"
                         }
                     ]
-                }
-            ],
-            [
-                "@semantic-release/exec",
-                {
-                    "successCmd": "PowerShell; Write-Host '##vso[Release.UpdateReleaseName]${nextRelease.version}'; Exit"
                 }
             ]
         ]


### PR DESCRIPTION
The `package.json` was previously using logging commands to rename
the Azure Pipelines release name but after moving it over to run as
a build instead this fails. The fix is to remove the logging
command.