### PR TITLE
docs(structure): adhere to unity technologies branding guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,16 +1,16 @@
 # Code of Conduct
 
-Contact: hello@vrtk.io
+Contact: hello@extendreality.io
 
 ## Why have a Code of Conduct?
 
 As contributors and maintainers of this project, we are committed to providing a friendly, safe and welcoming environment for all, regardless of age, disability, gender, nationality, race, religion, sexuality, or similar personal characteristic.
 
-The goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about VRTK effectively, productively, and respectfully, even in face of disagreements. The Code of Conduct also provides a mechanism for resolving conflicts in the community when they arise.
+The goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about Extend Reality Ltd products and repositories effectively, productively, and respectfully, even in face of disagreements. The Code of Conduct also provides a mechanism for resolving conflicts in the community when they arise.
 
 ## Our Values
 
-These are the values VRTK developers should aspire to:
+These are the values Extend Reality Ltd developers and repository contributors should aspire to:
 
   * Be friendly and welcoming
   * Be patient
@@ -35,18 +35,19 @@ The following actions are explicitly forbidden:
 
 ## Where does the Code of Conduct apply?
 
-If you participate in or contribute to the VRTK ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
+If you participate in or contribute to the Extend Reality Ltd ecosystem in any way, you are encouraged to follow the Code of Conduct while doing so.
 
-Explicit enforcement of the Code of Conduct applies to the official mediums operated by the VRTK project:
+Explicit enforcement of the Code of Conduct applies to the official mediums operated by the Extend Reality Ltd project:
 
 * The official GitHub projects and code reviews.
-* The official VRTK slack channel.
+* The official slack channels.
+* The official forums.
 
-Other VRTK activities (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
+Other Extend Reality Ltd product and company activities (such as conferences, meetups, and other unofficial forums) are encouraged to adopt this Code of Conduct. Such groups must provide their own contact information.
 
 Project maintainers may remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing: hello@vrtk.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. **All reports will be kept confidential**.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing: hello@extendreality.io. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. **All reports will be kept confidential**.
 
 **The goal of the Code of Conduct is to resolve conflicts in the most harmonious way possible**. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort. **Do not** post about the issue publicly or try to rally sentiment against a particular individual or group.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,27 +1,18 @@
 # Contributing
 
-We are keen for developers to contribute to open source projects to
-keep them great!
+We are keen for developers to contribute to open source projects to keep them great!
 
-Whilst every effort is made to provide features that will assist a wide
-range of development cases, it is inevitable that we will not cater for
-all situations.
+Whilst every effort is made to provide features that will assist a wide range of development cases, it is inevitable that we will not cater for all situations.
 
-Therefore, if you feel that your custom solution is generic and
-would assist other developers then we would love to review your
-contribution.
+Therefore, if you feel that your custom solution is generic and would assist other developers then we would love to review your contribution.
 
-There are however, a few guidelines that we need contributors to
-follow so that we can have a chance of keeping on top things.
+There are however, a few guidelines that we need contributors to follow so that we can have a chance of keeping on top things.
 
 ## Getting Started
   * Make sure you have a GitHub account.
-  * Create a new issue on the GitHub repository, providing one does
-  not already exist.
-   * Clearly describe the issue including steps to reproduce when it
-   is a bug (fill out the issue template).
-   * Make sure you fill in the earliest version that you know has
-   the issue.
+  * Create a new issue on the GitHub repository, providing one does not already exist.
+   * Clearly describe the issue including steps to reproduce when it is a bug (fill out the issue template).
+   * Make sure you fill in the earliest version that you know has the issue.
   * Fork the repository on GitHub.
 
 ## Making Changes
@@ -29,34 +20,21 @@ follow so that we can have a chance of keeping on top things.
   * Create a topic branch from where you want to base your work.
    * If you're fixing a bug then target the `master` branch.
    * If you're creating a new feature then target a release branch.
-   * Name your branch with the type of issue you are fixing;
-   `feat`, `chore`, `docs`.
+   * Name your branch with the type of issue you are fixing; `feat`, `chore`, `docs`.
    * Please avoid working directly on your master branch.
+  * Make sure you set the `Asset Serialization` mode in `Unity->Edit->Project Settings->Editor` to `Force Text`.
   * Make commits of logical units.
   * Make sure your commit messages are in the proper format.
 
-Following the above method will ensure that all bug fixes are pushed
-to the `master` branch while all new features will be pushed to the
-relevant next release branch. This means that patch releases are
-much easier to do as the `master` branch will only contain bug fixes
-so will be used to fork into new patch releases. Then master will be
-rebased into the relevant next release branch so the next release also
-contains the updated bug fixes in the previous patch release.
+Following the above method will ensure that all bug fixes are pushed to the `master` branch while all new features will be pushed to the relevant next release branch. This means that patch releases are much easier to do as the `master` branch will only contain bug fixes so will be used to fork into new patch releases. Then master will be rebased into the relevant next release branch so the next release also contains the updated bug fixes in the previous patch release.
 
 ## Coding Conventions
 
-To ensure all code is consistent and readable, we adhere to the
-default coding conventions utilised in Visual Studio. The easiest
-first step is to auto format the code within Visual Studio with
-the key combination of `Ctrl + k` then `Ctrl + d` which will ensure
-the code is correctly formatted and indented.
+To ensure all code is consistent and readable, we adhere to the default coding conventions utilised in Visual Studio. The easiest first step is to auto format the code within Visual Studio with the key combination of `Ctrl + k` then `Ctrl + d` which will ensure the code is correctly formatted and indented.
 
-Spaces should be used instead of tabs for better readability across
-a number of devices (e.g. spaces look better on Github source view.)
+Spaces should be used instead of tabs for better readability across a number of devices (e.g. spaces look better on Github source view.)
 
-In regards to naming conventions we also adhere to the
-[standard .NET Framework naming convention system](https://msdn.microsoft.com/en-gb/library/x2dbyw72(v=vs.71).aspx)
-and use American spellings to denote classes, methods, fields, etc.
+In regards to naming conventions we also adhere to the [standard .NET Framework naming convention system](https://msdn.microsoft.com/en-gb/library/x2dbyw72(v=vs.71).aspx) and use American spellings to denote classes, methods, fields, etc.
 
   > **Incorrect:**
   ```
@@ -68,23 +46,7 @@ and use American spellings to denote classes, methods, fields, etc.
   public Color fontColor;
   ```
 
-Class methods and parameters should always denote their accessibility
-level using the `public` `protected` `private` keywords. Methods should
-also always be defined as virtual in concrete classes to allow
-overriding.
-
-  > **Incorrect:**
-  ```
-  void MyMethod()
-  ```
-
-  > **Correct:**
-  ```
-  protected virtual void MyMethod()
-  ```
-
-All core classes should be within the relevant namespace. Any
-required `using` lines should be within the namespace block.
+All core classes should be within the relevant `Zinnia` namespace. Any required `using` lines should be within the namespace block.
 
   > **Incorrect:**
   ```
@@ -99,13 +61,90 @@ required `using` lines should be within the namespace block.
 
   > **Correct:**
   ```
-  namespace X.Y.Z
+  namespace Zinnia.X.Y.Z
   {
     using System;
+
     public class MyClass
     {
     }
   }
+  ```
+
+Names of classes should always be a noun describing what the component's role is.
+
+  > **Incorrect:**
+  ```
+  public class UpdateThing;
+  ```
+
+  > **Correct:**
+  ```
+  public class ThingUpdater;
+  ```
+
+Names of methods should always be a verb describing the action that the method will carry out. Methods should also do a specific task which the name clearly highlights. Any use of the word `And`/`Or` in a method name highlights the potential issue that a method is doing too much.
+
+  > **Incorrect:**
+  ```
+  public virtual void ContainerPosition();
+  public virtual void ContainerPositionAndRotation();
+  public virtual void ContainerPositionOrRotation();
+  public virtual void Setup();
+  ```
+
+  > **Correct:**
+  ```
+  public virtual void UpdateContainerPosition();
+  public virtual void UpdateContainerRotation();
+  public virtual void SetUpContainer();
+  ```
+
+The only deviation from the MSDN conventions are fields should start with lowercase -> `public Type myField` as this is inline with Unity's naming convention.
+
+Names of fields and properties should always be an adjective with a clear understanding of what the variable is describing. It is also not necessary to repeat the type name in the variable name as it should be implicitly understood from the naming of the variable.
+
+  > **Incorrect:**
+  ```
+  public GameObject go;
+  public GameObject jointGameObject;
+  ```
+
+  > **Correct:**
+  ```
+  public GameObject jointContainer;
+  ```
+
+Inline variable declarations should also follow the same naming rules and be clear and concise to their purpose. They should not be abbreviated which can cause confusion whilst reading the code.
+
+  > **Incorrect:**
+  ```
+  for (int i = 0; i < 10; i++) {}
+  for (int x = 0; x < 10; x++)
+  {
+    for (int y = 0; y < 10; y++) {}
+  }
+  ```
+
+  > **Correct:**
+  ```
+  for (int index = 0; index < 10; index++) {}
+  for (int containerIndex = 0; containerIndex < 10; containerIndex++)
+  {
+    for (int clipIndex = 0; clipIndex < 10; clipIndex++) {}
+  }
+  ```
+
+Class methods and parameters should always denote their accessibility level using the `public` `protected` `private` keywords. Methods should also always be defined as virtual in concrete classes to allow overriding. Marking as `protected` is favored until there is good reason to make it `private`. This ensures the type is open for extension where possible.
+
+  > **Incorrect:**
+  ```
+  void MyMethod()
+  ```
+
+  > **Correct:**
+  ```
+  protected virtual void MyMethod()
   ```
 
 The order elements are defined in a class should be as follows:
@@ -127,19 +166,11 @@ The order elements are defined in a class should be as follows:
   * private MonoBehaviour message methods
   * private methods
 
-It is acceptable to have multiple classes defined in the same file as
-long as the subsequent defined classes are only used by the main class
-defined in the same file. However, don't nest types as it makes it
-harder to find and reference them.
+It is acceptable to have multiple classes defined in the same file as long as the subsequent defined classes are only used by the main class defined in the same file. However, don't nest types as it makes it harder to find and reference them.
 
-Where possible, the structure of the code should also flow with the
-accessibility level of the method or parameters. So all `public`
-parameters and methods should be defined first, followed by `protected`
-parameters and methods with `private` parameters and methods being
-defined last.
+Where possible, the structure of the code should also flow with the accessibility level of the method or parameters. So all `public` parameters and methods should be defined first, followed by `protected` parameters and methods with `private` parameters and methods being defined last.
 
-Blocks of code such as conditional statements and loops must always
-contain the block of code in braces `{ }` even if it is just one line.
+Blocks of code such as conditional statements and loops should contain the block of code in braces `{ }` even if it is just one line.
 
   > **Incorrect:**
   ```
@@ -154,56 +185,46 @@ contain the block of code in braces `{ }` even if it is just one line.
   }
   ```
 
-Any method or variable references should have the most simplified name
-as possible, which means no additional references should be added where
-it's not necessary.
+The only exception to this is when defining Property get/set fields that only require one line:
+
+  > **Example:**
+  ```
+  public Type MyType
+  {
+    get { return _backingType; }
+    set
+    {
+      _backingType = value;
+      ConfigureMyType(_backingType);
+    }
+  }
+  ```
+
+Any method or variable references should have the most simplified name as possible, which means no additional references should be added where it's not necessary.
 
   > `this.transform.rotation` *is simplified to* `transform.rotation`
 
   > `GameObject.FindObjectsOfType` *is simplified to* `FindObjectsOfType`
 
-All MonoBehaviour inherited classes that implement a MonoBehaviour
-[Message](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html)
-method must at least be `protected virtual` to allow any further
-inherited class to override and extend the methods.
+All MonoBehaviour inherited classes that implement a MonoBehaviour [Message](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html) method must at least be `protected virtual` to allow any further inherited class to override and extend the methods.
 
-When defining arrays, it is appropriate to instantiate the array with
-the `System.Array.Empty<T>()` notation instead of doing `new Array[0]`.
+When defining arrays, it is appropriate to instantiate the array with the `System.Array.Empty<T>()` notation instead of doing `new Array[0]`.
 
-In Unity scripts all events should be UnityEvents and not C#
-delegates as this will automatically provide inspector helpers for
-hooking up listeners. Any custom UnityEvent should be defined as a
-nested class.
+All events should be UnityEvents and not C# delegates as this will automatically provide inspector helpers for hooking up listeners. Any custom UnityEvent should be defined as a nested class and the final parameter should always be an `object` type so the sender of the event can be passed in the payload.
 
-When the actual UnityEvent is defined in code it should also be
-instantiated so it is not null at runtime.
+When the actual UnityEvent is defined in code it should also be instantiated so it is not null at runtime.
 
 `public MyEventClass MyEventAction = new MyEventClass();`
 
-Public fields that are collections should favour the
-`System.Collections.Generic.List` data type over a simple `array` as
-the `List` offers helper operators for mutating the contents of the
-list (e.g. `Add` `Remove` `Clear`). This makes it easier when accessing
-the collection via another script when the contents of the collection
-requires changing.
+Public fields that are collections should favour the `System.Collections.Generic.List` data type over a simple `array` as the `List` offers helper operators for mutating the contents of the list (e.g. `Add` `Remove` `Clear`). This makes it easier when accessing the collection via another script when the contents of the collection requires changing.
 
 ## Documentation
 
-All core scripts, abstractions, controls and prefabs should contain
-inline code documentation adhering to the
-[.NET Framework XML documentation comments convention](https://msdn.microsoft.com/en-us/library/b2s063f7.aspx)
+All core scripts, abstractions, controls and prefabs should contain inline code documentation adhering to the [.NET Framework XML documentation comments convention](https://msdn.microsoft.com/en-us/library/b2s063f7.aspx)
 
-All classes, methods and unity events should be documented using
-the XML comments and contain a 1 line `<summary>` with any additional
-lines included in `<remarks>`.
+All classes, methods and unity events should be documented using the XML comments and contain a 1 line `<summary>` with any additional lines included in `<remarks>`.
 
-Public serialized parameters that appear in the inspector also require
-XML comments and an additional `[Tooltip("")]` which is displayed in
-the Unity Editor inspector panel. All parameter attributes should
-appear in the same attribute block and comma separated with the
-`Tooltip` attribute first followed by the remaining attributes in an
-order that makes most sense when read as a sentence. The order of
-documentation and parameter attributes should be:
+Public serialized parameters that appear in the inspector also require XML comments and an additional `[Tooltip("")]` which is displayed in the Unity Editor inspector panel. All parameter attributes should appear in the same attribute block and comma separated with the `Tooltip` attribute first followed by the remaining attributes in an order that makes most sense when read as a sentence. The order of documentation and parameter attributes should be:
 
   * XML documentation
   * Parameter attributes
@@ -217,13 +238,7 @@ documentation and parameter attributes should be:
   protected Type myType;
   ```
 
-If a `[Header]` attribute is to be used to group fields in the Unity
-Inspector, then the attribute must preceed the `Tooltip` attribute in
-the comma separated list and not be on it's own line above the XML
-summary as the MSDN specification dictates that attributes must
-annotate members. It is also advised to wrap `Header` sections using
-the `#region` directive to denote the block assoicated.
-The following shows a valid and invalid example:
+If a `[Header]` attribute is to be used to group fields in the Unity Inspector, then the attribute must preceed the `Tooltip` attribute in the comma separated list and not be on it's own line above the XML summary as the MSDN specification dictates that attributes must annotate members. It is also advised to wrap `Header` sections using the `#region` directive to denote the block assoicated. The following shows a valid and invalid example:
 
   > **Incorrect:**
   ```
@@ -246,24 +261,15 @@ The following shows a valid and invalid example:
   #endregion
   ```
 
-Whenever an inherited field, method, etc. is overridden then the
-documentation should avoid repeating itself from the base class and
-instead should use the `/// <inheritdoc />` notation instead. Despite
-not being needed, being explicit about inheriting the documentation
-simplifies checking contributions for proper documentation.
+Whenever an inherited field, method, etc. is overridden then the documentation should avoid repeating itself from the base class and instead should use the `/// <inheritdoc />` notation instead. Despite not being needed, being explicit about inheriting the documentation simplifies checking contributions for proper documentation.
 
-Any references to other classes, methods or parameters should also use
-the `<see>` notation within the documentation.
+Any references to other classes, methods or parameters should also use the `<see>` notation within the documentation.
 
 ## Commit Messages
 
-All pull request commit messages are automatically checked using
-[GitCop](http://gitcop.com) - this will inform you if there are any
-issues with your commit message and give you an opportunity to rectify
-any issues.
+All pull request commit messages are automatically checked using [GitCop](http://gitcop.com) - this will inform you if there are any issues with your commit message and give you an opportunity to rectify any issues.
 
-The commit message lines should never exceed 72 characters and should
-be entered in the following format:
+The commit message lines should never exceed 72 characters and should be entered in the following format:
 
   > **Example:**
   ```
@@ -283,30 +289,23 @@ The type must be one of the following:
   * refactor: A code change that neither fixes a bug or adds a feature.
   * perf: A code change that improves performance.
   * test: Adding missing tests.
-  * chore: Changes to the build process or auxiliary tools or
-  libraries such as documentation generation.
+  * chore: Changes to the build process or auxiliary tools or libraries such as documentation generation.
 
 ### Scope
 
-The scope could be anything specifying the place of the commit change,
-such as, `Controller`, `Interaction`, `Locomotion`, etc...
+The scope could be anything specifying the place of the commit change, such as, `Controller`, `Interaction`, `Locomotion`, etc...
 
 ### Subject
 
 The subject contains succinct description of the change:
 
-  * use the imperative, present tense: "change" not "changed" nor
-  "changes".
-  * don't capitalize first letter, unless naming something, such as
-  `Bootstrap`.
+  * use the imperative, present tense: "change" not "changed" nor "changes".
+  * don't capitalize first letter, unless naming something, such as `Bootstrap`.
   * no dot (.) at the end of the subject line.
 
 ### Body
 
-Just as in the subject, use the imperative, present tense: "change"
-not "changed" nor "changes" The body should include the motivation for
-the change and contrast this with previous behaviour. References to
-previous commit hashes is actively encouraged if they are relevant.
+Just as in the subject, use the imperative, present tense: "change" not "changed" nor "changes" The body should include the motivation for the change and contrast this with previous behaviour. References to previous commit hashes is actively encouraged if they are relevant.
 
   > **Incorrect commit summary:**
   ```
@@ -329,5 +328,4 @@ previous commit hashes is actively encouraged if they are relevant.
 ## Submitting Changes
   * Push your changes to your topic branch in your repository.
   * Submit a pull request to this repository.
-  * The core team will aim to look at the pull request as soon as
-  possible and provide feedback where required.
+  * The core team will aim to look at the pull request as soon as possible and provide feedback where required.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,16 +2,15 @@
 
 ### Precheck
 
- * Do not use the issues tracker for help or support (try VRTK Slack channel, Stack Overflow, etc.)
+ * Do not use the issues tracker for help or support (try Stack Overflow, etc.)
  * For proposing a new feature, please check existing open and closed issues before creating a duplicate
  * For bugs, do a quick search and make sure the bug has not yet been reported
  * Finally, be excellent to each other, and party on!
 
 ### Environment
 
- * Source of the repo (Unity Asset Store or Github)
- * Version of repo (Unity Asset Store/Github release number) (Github master commit hash)
- * Version of Unity3D (e.g. Unity 2018.1)
+ * Version of Malimbe (Github release number) (Github branch and commit hash)
+ * Version of the Unity software (e.g. Unity 2018.3)
 
 ### Steps to reproduce
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,1 @@
 Only submit an issue if you have a known bug or are requesting a new feature.
-
-If you require help or support then ask a question in the official VRTK Slack channel at http://invite.vrtk.io

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Extend Reality Ltd
+Copyright (c) 2018-2019 Extend Reality Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 [![Malimbe logo][Malimbe-Image]](#)
 
 > ### Malimbe
-> A collection of tools to simplify writing public API components in Unity.
+> A collection of tools to simplify writing public API components for the Unity software.
 
 [![License][License-Badge]][License]
 [![Waffle][Waffle-Badge]][Waffle]
 
 ## Introduction
 
-Malimbe is a collection of tools to simplify writing public API components in Unity.
+Malimbe for the [Unity] software aims to reduce repetitive boilerplate code by taking the assemblies that are created by build tools and changing the assembly itself, new functionality can be introduced and logic written as part of the source code can be altered. This process is called Intermediate Language (IL) weaving and Malimbe uses [Fody] to do it.
 
-By taking the assemblies that are created by build tools and changing the assembly itself, repetetive boilerplate can be reduced, new functionality can be introduced and logic written as part of the source code can be altered. This process is called Intermediate Language (IL) weaving and Malimbe uses [Fody] to do it.
-
-Malimbe helps running Fody and Fody addins without MSBuild or Visual Studio and additionally offers running them inside Unity by integrating with Unity's compilation and build pipeline. Multiple weavers come with Malimbe to help with boilerplate one has to write when creating Unity components that are intended for public consumption. This includes a form of "serialized properties", getting rid of duplicated documentation through XML documentation and the `[Tooltip]` attribute as well as weavers that help with ensuring the API is able to be called from `UnityEvent`s and more.
+Malimbe helps running Fody and Fody addins without MSBuild or Visual Studio and additionally offers running them inside the Unity software by integrating with the Unity software compilation and build pipeline. Multiple weavers come with Malimbe to help with boilerplate one has to write when creating Unity software components that are intended for public consumption. This includes a form of "serialized properties", getting rid of duplicated documentation through XML documentation and the `[Tooltip]` attribute as well as weavers that help with ensuring the API is able to be called from `UnityEvent`s and more.
 
 ## Releases
 
@@ -25,11 +23,11 @@ Releases follow the [Semantic Versioning (SemVer) system][SemVer].
 
 ## Getting Started
 
-Please follow these steps to install the package using a local location until Unity's Package Manager (UPM) allows third parties to publish packages to the UPM feed:
+Please follow these steps to install the package using a local location until the Unity Package Manager (UPM) allows third parties to publish packages to the UPM feed:
 
 1. Download a release from the [Releases] page and extract it into your folder you use to keep your packages. It is recommended to make that folder part of your project and therefore [version controlled][VCS].
-1. Open your Unity (`>= 2018.3`) project and follow [Unity's instructions][UPM-Instructions] on how to add the package to your project using UPM.
-1. Anywhere in your Unity project add a [`FodyWeavers.xml` file][FodyWeavers].
+1. Open your project created with the Unity software version 2018.3 (or above) project and follow [Unity's instructions][UPM-Instructions] on how to add the package to your project using UPM.
+1. Anywhere in your Unity software project add a [`FodyWeavers.xml` file][FodyWeavers].
 1. Configure the various weavers Malimbe offers, e.g.:
     ```xml
     <?xml version="1.0" encoding="utf-8"?>
@@ -50,7 +48,7 @@ Please follow these steps to install the package using a local location until Un
 
     In case there are multiple configuration files all of them will be used. In that scenario, if multiple configuration files specify settings for the same weaver, a weaver will be configured using the values in the _last_ configuration file found. A warning is logged to notify of this behavior and to allow fixing potential issues that may arise by ensuring only a single configuration exists for any used weaver.
 
-Additional weavers are supported. To allow Malimbe's Unity integration to find the weavers' assemblies they have to be included anywhere in the Unity project or in one of the UPM packages the project uses.
+Additional weavers are supported. To allow Malimbe's Unity software integration to find the weavers' assemblies they have to be included anywhere in the Unity software project or in one of the UPM packages the project uses.
 
 ## What's In The Box
 
@@ -70,14 +68,14 @@ A standalone library that allows running Fody without MSBuild or Visual Studio.
 
 ### `FodyRunner.UnityIntegration`
 
-Weaves assemblies using `FodyRunner` in the Unity Editor after Unity compiled them.
+Weaves assemblies using `FodyRunner` in the Unity software Editor after the Unity softwared compiled them.
 
-* There is no need to manually run the weaving process. The library just needs to be part of a Unity project (it's configured to only run in the Editor) to be used. It hooks into the various callbacks Unity offers and automatically weaves any assembly on startup as well as when they change.
+* There is no need to manually run the weaving process. The library just needs to be part of a Unity software project (it's configured to only run in the Editor) to be used. It hooks into the various callbacks the Unity software offers and automatically weaves any assembly on startup as well as when they change.
 * Once the library is loaded in the Editor a menu item `Tools/Malimbe/Weave All Assemblies` allows to manually trigger the weaving process for all assemblies in the current project. This is useful when a `FodyWeavers.xml` file was changed.
 
 ### `BehaviourStateRequirementMethod`
 
-A Unity-specific weaver. Changes a method to return early if a combination of the GameObject's active state and the Behaviour's enabled state doesn't match the configured state.
+A Unity software specific weaver. Changes a method to return early if a combination of the GameObject's active state and the Behaviour's enabled state doesn't match the configured state.
 
 * Annotate a method with `[RequiresBehaviourState]` to use this. The method needs to be defined in a type that derives from `UnityEngine.Behaviour`, e.g. a `MonoBehaviour`.
 * Use the attribute constructor's parameters to configure the specific state you need the GameObject and the Behaviour to be in.
@@ -96,11 +94,11 @@ A generic weaver. Creates `ClearMemberName()` methods for any member `MemberName
 
 ### `PropertySerializationAttribute.Fody`
 
-A Unity-specific weaver. Ensures the backing field for a property is serialized.
+A Unity software specific weaver. Ensures the backing field for a property is serialized.
 
 * Annotate a property with `[Serialized]` to use this. The property needs both a getter and setter.
 * If the property's backing field doesn't use `[SerializeField]` it will be added.
-* If the property is an [auto-implemented property][Auto-Implemented Property] the backing field will be renamed to match the property's name for viewing in the Unity inspector. All backing field usages inside methods of the declaring type will be updated to use this new name. Since C# doesn't allow multiple members of a type to share a name, the backing field's name will differ in the first character's case. E.g.:
+* If the property is an [auto-implemented property][Auto-Implemented Property] the backing field will be renamed to match the property's name for viewing in the Unity software inspector. All backing field usages inside methods of the declaring type will be updated to use this new name. Since C# doesn't allow multiple members of a type to share a name, the backing field's name will differ in the first character's case. E.g.:
   * `public int Counter { get; set; }` will use a backing field called `counter`.
   * `protected bool isValid { get; private set; }` will use a backing field called `IsValid`.
 
@@ -113,7 +111,7 @@ A generic weaver. Calls a validation method at the start of a property's setter.
 
 ### `PropertyValidationMethod.Fody`
 
-A generic weaver (though made for Unity). Creates a `OnValidate()` method that validates a property.
+A generic weaver (though made for the Unity software). Creates a `OnValidate()` method that validates a property.
 
 * Annotate a property with `[Validated]` to use this. The property needs both a getter and setter.
 * Instead of `OnValidate` the method name can be customized with the XML _attribute_ `MethodName`, e.g.:
@@ -125,7 +123,7 @@ A generic weaver (though made for Unity). Creates a `OnValidate()` method that v
 
 ### `XmlDocumentationAttribute.Fody`
 
-A generic weaver (though made for Unity). Looks up the XML `<summary>` documentation for a field and adds `[Tooltip]` to that field with that summary.
+A generic weaver (though made for the Unity software). Looks up the XML `<summary>` documentation for a field and adds `[Tooltip]` to that field with that summary.
 
 * Annotate a field with `[DocumentedByXml]` to use this.
 * Instead of `TooltipAttribute` the added attribute can be customized with the XML _attribute_ `FullAttributeName`, e.g.:
@@ -142,7 +140,7 @@ A generic weaver (though made for Unity). Looks up the XML `<summary>` documenta
 
 ### `UnityPackaging`
 
-Outputs a ready-to-use folder with the appropriate hierarchy to copy into a Unity project's Assets folder. The output includes both the Unity integration libraries as well as all weavers and their attributes listed above.
+Outputs a ready-to-use folder with the appropriate hierarchy to copy into a Unity software project's Assets folder. The output includes both the Unity software integration libraries as well as all weavers and their attributes listed above.
 
 ## Contributing
 
@@ -164,6 +162,10 @@ Malimbe is released under the [MIT License][License].
 
 Third-party notices can be found in [THIRD_PARTY_NOTICES.md][ThirdPartyNotices]
 
+## Disclaimer
+
+These materials are not sponsored by or affiliated with Unity Technologies or its affiliates. "Unity" and "Unity Package Manager" are trademarks or registered trademarks of Unity Technologies or its affiliates in the U.S. and elsewhere.
+
 [Malimbe-Image]: https://user-images.githubusercontent.com/1029673/48707109-4d876080-ebf6-11e8-9476-4f084246771d.png
 [License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Malimbe.svg
 [Waffle-Badge]: https://badge.waffle.io/ExtendRealityLtd/Malimbe.svg?columns=Bug%20Backlog,Feature%20Backlog,In%20Progress,In%20Review
@@ -178,6 +180,7 @@ Third-party notices can be found in [THIRD_PARTY_NOTICES.md][ThirdPartyNotices]
 [FodyWeavers]: https://github.com/Fody/Fody#add-fodyweaversxml
 [Regex]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expressions
 [Auto-Implemented Property]: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/auto-implemented-properties
+[Unity]: https://unity3d.com/
 
 [Fody's naming]: https://github.com/Fody/Fody#naming
 [Malimbus]: https://en.wikipedia.org/wiki/Malimbus


### PR DESCRIPTION
The use of the wordmark `Unity` has been updated in the README to
clearly adhere to the guidelines laid out by Unity Technologies at
https://unity3d.com/legal/branding_trademarks and a disclaimer
has been added to clearly outline that this repository is not in
affiliation with Unity Technologies.

Any reference to VRTK has been updated to reference the Extend
Reality Ltd company entity as this is the appropriate governing
body of the repository.

The CONTRIBUTING.md has also been updated to remove the unnecessary
72 character line limit.

The LICENSE.md file has also been updated to extend the copyright
to 2019 as changes have been made in this year as well.