### PR TITLE
feat(Runner): only run on specified assemblies - Resolves #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Please follow these steps to install the package using a local location until th
     <Weavers>
       <Malimbe.FodyRunner>
         <LogLevel>Error, Warning</LogLevel>
+        <AssemblyNameRegex>^Zinnia</AssemblyNameRegex>
+        <AssemblyNameRegex>^Assembly-CSharp</AssemblyNameRegex>
       </Malimbe.FodyRunner>
       <Malimbe.BehaviourStateRequirementMethod/>
       <Malimbe.MemberClearanceMethod/>
@@ -58,13 +60,14 @@ Malimbe is a _collection_ of tools. Each project represents a solution to a spec
 
 A standalone library that allows running Fody without MSBuild or Visual Studio.
 
-* Use the XML element `LogLevel` to specify which log messages should be sent to the logger instance. Separate multiple levels by using multiple XML elements or separate inside an XML element by using any form of whitespace including newlines or commas. Valid values are
+* Use the XML _element_ `LogLevel` to specify which log messages should be sent to the logger instance. Separate multiple levels by using multiple XML elements or separate inside an XML element by using any form of whitespace including newlines or commas. Valid values are
   * `None` (or don't specify `LogLevel`)
   * `Debug`
   * `Info`
   * `Warning`
   * `Error`
   * `All`
+* Add XML _elements_ `AssemblyNameRegex` for each assembly that should be processed. Specifying none will result in no assembly being processed and a warning being logged. The elements' values are used as ([.NET Standard's][Regex]) regular expressions.
 
 ### `FodyRunner.UnityIntegration`
 


### PR DESCRIPTION
Running on all assemblies is often unnecessary, wasting performance
or even not intended. A new XML element `AssemblyNameRegex` has been
added that allows specifying which assemblies to process.

BREAKING CHANGE: The assemblies to process have to be specified
using the XML _element_ `AssemblyNameRegex` from now on. Specifying
none will result in no assembly being processed and a warning being
logged.