### PR TITLE
feat(PropertySetter): allow using property inside called method - resolves #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ A Unity software specific weaver. Ensures the backing field for a property is se
 
 ### `PropertySetterMethod.Fody`
 
-A generic weaver. Calls a validation method at the start of a property's setter.
+A generic weaver. Calls a method at the end of a property's setter.
 
-* Annotate a method with `[SetsProperty(nameof(SomeProperty))]` to use this. The method needs to follow the signature pattern `T MethodName(T, T)` where `T` is the property's type. The accessibility level of the method doesn't matter and the name lookup is case insensitive. A call to this method will be added to the _start_ of the property's setter.
+* Annotate a method with `[CalledBySetter(nameof(SomeProperty))]` to use this. The accessibility level of the method doesn't matter and the name lookup is case insensitive. A call to this method will be added to the _end_ of the property's setter.
+* The method needs to follow the signature pattern `void MethodName(T previousValue, ref T newValue)` where `T` is the property's type. This allows the method's body to use the previous and new values and also offers the ability to change the final value by setting `newValue` if needed.
 * The property needs to be declared in the same type the method is declared in. Both a getter and setter are required for the property.
 
 ### `PropertyValidationMethod.Fody`

--- a/Sources/PropertySetterMethod/CalledBySetterAttribute.cs
+++ b/Sources/PropertySetterMethod/CalledBySetterAttribute.cs
@@ -3,13 +3,13 @@
     using System;
 
     /// <summary>
-    /// Indicates that the method acts as a setter for a property.
+    /// Indicates that the method is called inside the setter of a property.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public sealed class SetsPropertyAttribute : Attribute
+    public sealed class CalledBySetterAttribute : Attribute
     {
         /// <summary>
-        /// The name of the property this methods acts as a setter for.
+        /// The name of the property this method will be called from.
         /// </summary>
         /// <remarks>
         /// The property needs to be declared in the same type this attribute is used in and needs both a getter and setter of any accessibility.
@@ -19,10 +19,10 @@
         public readonly string PropertyName;
 
         /// <summary>
-        /// Indicates that the method acts as a setter for a property.
+        /// Indicates that the method is called inside the setter of a property.
         /// </summary>
-        /// <param name="propertyName">The name of the property this methods acts as a setter for.</param>
-        public SetsPropertyAttribute(string propertyName) =>
+        /// <param name="propertyName">The name of the property this method will be called from.</param>
+        public CalledBySetterAttribute(string propertyName) =>
             PropertyName = propertyName;
     }
 }


### PR DESCRIPTION
If the annotated method tried to call another method that uses the
property it would end up working on the previous value instead of
whatever this method returns. This change allows to set the value of
the property's backing field at any time, thus it can be set before
calling a method that needs the latest property value by calling the
property's getter.

BREAKING CHANGE: `SetsPropertyAttribute` was renamed to
`CalledBySetterAttribute` and the expected signature of the
annotated method changed. Please see the latest Readme for details.