### PR TITLE
fix(RequiredBehaviourStateAttribute): don't use isActiveAndEnabled

### DIFF
--- a/Sources/BehaviourStateRequirementMethod.Fody/ModuleWeaver.cs
+++ b/Sources/BehaviourStateRequirementMethod.Fody/ModuleWeaver.cs
@@ -147,45 +147,31 @@
 
             int index = -1;
 
-            if (gameObjectActivity == GameObjectActivity.InHierarchy && behaviourNeedsToBeEnabled)
+            if (gameObjectActivity != GameObjectActivity.None)
             {
-                // Load this (for isActiveAndEnabled getter call)
+                // Load this (for gameObject getter call)
                 instructions.Insert(++index, Instruction.Create(OpCodes.Ldarg_0));
-                // Call isActiveAndEnabled getter
-                instructions.Insert(
-                    ++index,
-                    Instruction.Create(OpCodes.Callvirt, _getIsActiveAndEnabledMethodReference));
+                // Call gameObject getter
+                instructions.Insert(++index, Instruction.Create(OpCodes.Callvirt, _getGameObjectMethodReference));
+
+                // ReSharper disable once SwitchStatementMissingSomeCases
+                switch (gameObjectActivity)
+                {
+                    case GameObjectActivity.Self:
+                        // Call activeSelf getter
+                        instructions.Insert(
+                            ++index,
+                            Instruction.Create(OpCodes.Callvirt, _getActiveSelfMethodReference));
+                        break;
+                    case GameObjectActivity.InHierarchy:
+                        // Call activeInHierarchy getter
+                        instructions.Insert(
+                            ++index,
+                            Instruction.Create(OpCodes.Callvirt, _getActiveInHierarchyMethodReference));
+                        break;
+                }
 
                 AddEarlyReturnInstruction(instructions, ref index, earlyReturnInstruction);
-            }
-            else
-            {
-                if (gameObjectActivity != GameObjectActivity.None)
-                {
-                    // Load this (for gameObject getter call)
-                    instructions.Insert(++index, Instruction.Create(OpCodes.Ldarg_0));
-                    // Call gameObject getter
-                    instructions.Insert(++index, Instruction.Create(OpCodes.Callvirt, _getGameObjectMethodReference));
-
-                    // ReSharper disable once SwitchStatementMissingSomeCases
-                    switch (gameObjectActivity)
-                    {
-                        case GameObjectActivity.Self:
-                            // Call activeSelf getter
-                            instructions.Insert(
-                                ++index,
-                                Instruction.Create(OpCodes.Callvirt, _getActiveSelfMethodReference));
-                            break;
-                        case GameObjectActivity.InHierarchy:
-                            // Call activeInHierarchy getter
-                            instructions.Insert(
-                                ++index,
-                                Instruction.Create(OpCodes.Callvirt, _getActiveInHierarchyMethodReference));
-                            break;
-                    }
-
-                    AddEarlyReturnInstruction(instructions, ref index, earlyReturnInstruction);
-                }
 
                 if (behaviourNeedsToBeEnabled)
                 {


### PR DESCRIPTION
Unity contains a bug wherein `isActiveAndEnabled` can be `false` even though both `enabled` and `gameObject.activeSelf` are `true`. `isActiveAndEnabled` is largely a convenience and by checking `enabled` and `gameObject.activeInHierarchy` this issue is avoided while remaining functionally identical.

This change was designed by @bddckr and discussed on Slack. I have tested the change and confirmed it indeed works around the Unity issue.