### PR TITLE
fix(MemberChange): refactor custom inspector logic to be composable

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: ExtendRealityLtd/DevOps
-      ref: refs/tags/v3.12.0
+      ref: refs/tags/v3.12.1
       endpoint: ExtendRealityLtd
 
 variables:

--- a/Sources/FodyRunner.UnityIntegration/InspectorEditor.cs
+++ b/Sources/FodyRunner.UnityIntegration/InspectorEditor.cs
@@ -1,10 +1,10 @@
 ﻿namespace Malimbe.FodyRunner.UnityIntegration
 {
+    using Malimbe.MemberChangeMethod;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using Malimbe.MemberChangeMethod;
     using UnityEditor;
     using UnityEngine;
     using Object = UnityEngine.Object;
@@ -19,17 +19,22 @@
         /// <summary>
         /// The key to use to store and retrieve <see cref="UndoRedoWarningPropertyPath"/> into/from <see cref="SessionState"/>.
         /// </summary>
-        protected static readonly string UndoRedoWarningSessionStateKey =
-            typeof(InspectorEditor).FullName + nameof(UndoRedoWarningPropertyPath);
+        protected static readonly string UndoRedoWarningSessionStateKey = typeof(InspectorEditor).FullName + nameof(UndoRedoWarningPropertyPath);
+        /// <summary>
+        /// The script property name.
+        /// </summary>
+        protected static readonly string ScriptProperty = "m_Script";
+        /// <summary>
+        /// The message text displayed in the Undo/Redo warning message.
+        /// </summary>
+        protected static readonly string UndoRedoWarningMessage = "Undo/redo is unsupported for this field at runtime: The change won't be noticed by components depending on it.";
         /// <summary>
         /// <see cref="SerializedProperty.propertyPath"/> of the property changed most recently, <see langword="null"/> if no property has been changed yet.
         /// </summary>
         protected static string UndoRedoWarningPropertyPath
         {
-            get =>
-                SessionState.GetString(UndoRedoWarningSessionStateKey, null);
-            set =>
-                SessionState.SetString(UndoRedoWarningSessionStateKey, value);
+            get => SessionState.GetString(UndoRedoWarningSessionStateKey, null);
+            set => SessionState.SetString(UndoRedoWarningSessionStateKey, value);
         }
 
         /// <summary>
@@ -42,102 +47,20 @@
         {
             serializedObject.Update();
 
-            SerializedProperty property = serializedObject.GetIterator();
-            if (!property.NextVisible(true))
+            SerializedProperty property = GetObjectProperties();
+            if (property == null)
             {
                 return;
             }
 
-            string undoRedoWarningPropertyPath = UndoRedoWarningPropertyPath;
-
-            do
-            {
-                string propertyPath = property.propertyPath;
-                Object targetObject = property.serializedObject.targetObject;
-
-                using (EditorGUI.ChangeCheckScope changeCheckScope = new EditorGUI.ChangeCheckScope())
-                using (new EditorGUI.DisabledGroupScope(propertyPath == "m_Script"))
-                {
-                    bool showUndoRedoWarning = Application.isPlaying && propertyPath == undoRedoWarningPropertyPath;
-                    if (showUndoRedoWarning)
-                    {
-                        EditorGUILayout.BeginVertical(GUI.skin.box);
-                        EditorGUILayout.HelpBox(
-                            "Undo/redo is unsupported for this field at runtime:"
-                            + " The change won't be noticed by components depending on it.",
-                            MessageType.Warning);
-                        EditorGUI.indentLevel++;
-                    }
-
-                    DrawProperty(property);
-
-                    if (showUndoRedoWarning)
-                    {
-                        EditorGUILayout.EndVertical();
-                        EditorGUI.indentLevel--;
-                    }
-
-                    // No change has been done, nothing to do.
-                    if (!changeCheckScope.changed)
-                    {
-                        continue;
-                    }
-
-                    // At design time we need to still allow Unity to persist the change and enable undo.
-                    if (!Application.isPlaying
-                        || (targetObject is Behaviour behaviour && !behaviour.isActiveAndEnabled))
-                    {
-                        ApplyModifiedProperty(property, false);
-                        continue;
-                    }
-
-                    FindChangeHandlerMethods(property);
-
-                    // There are change handlers. Run them manually and ensure Unity knows those change handlers did some changes (to persist them and enable undo for them).
-                    if (ChangeHandlerMethodInfos.Count > 0)
-                    {
-                        Undo.RecordObject(targetObject, "Before change handlers");
-                        BeforeChange(property);
-                        Undo.FlushUndoRecordObjects();
-
-                        using (SerializedObject serializedObjectCopy =
-                            new SerializedObject(property.serializedObject.targetObject))
-                        {
-                            SerializedProperty propertyCopy = serializedObjectCopy.GetIterator();
-                            if (propertyCopy.Next(true))
-                            {
-                                do
-                                {
-                                    if (propertyCopy.propertyPath != property.propertyPath)
-                                    {
-                                        property.serializedObject.CopyFromSerializedProperty(propertyCopy);
-                                    }
-                                }
-                                while (propertyCopy.Next(false));
-                            }
-                        }
-
-                        ApplyModifiedProperty(property, true);
-                        AfterChange(property);
-                    }
-                    // Ensure subclasses of this inspector can run before/after change logic. Also ensure Unity persists the change (including undo support).
-                    else
-                    {
-                        BeforeChange(property);
-                        ApplyModifiedProperty(property, false);
-                        AfterChange(property);
-                    }
-                }
-            }
-            while (property.NextVisible(false));
+            ProcessObjectProperties(property);
         }
 
         /// <summary>
         /// Draws the given property.
         /// </summary>
         /// <param name="property">The property to draw.</param>
-        protected virtual void DrawProperty(SerializedProperty property) =>
-            EditorGUILayout.PropertyField(property, true);
+        protected virtual void DrawProperty(SerializedProperty property) => EditorGUILayout.PropertyField(property, true);
 
         /// <summary>
         /// Applies modifications to the given <see cref="SerializedProperty"/>.
@@ -250,6 +173,166 @@
             while (fieldInfo == null && type != null);
 
             return fieldInfo;
+        }
+
+        /// <summary>
+        /// Attempts to retrieve all properties associated to the <see cref="serializedObject"/>.
+        /// </summary>
+        /// <returns>A <see cref="SerializedProperty"/> collection.</returns>
+        protected virtual SerializedProperty GetObjectProperties()
+        {
+            SerializedProperty property = serializedObject.GetIterator();
+            if (!property.NextVisible(true))
+            {
+                return null;
+            }
+
+            return property;
+        }
+
+        /// <summary>
+        /// Whether to show the Undo/Redo warning in the inspector.
+        /// </summary>
+        /// <param name="propertyPath">The current path of the property to check.</param>
+        /// <param name="undoRedoWarningPropertyPath">The path to the undo/redo warning for the property.</param>
+        /// <returns>Whether the Undo/Redo warning should be shown.</returns>
+        protected virtual bool CanShowUndoRedoWarning(string propertyPath, string undoRedoWarningPropertyPath)
+        {
+            return Application.isPlaying && propertyPath == undoRedoWarningPropertyPath;
+        }
+
+        /// <summary>
+        /// Whether to apply the change handlers for the property.
+        /// </summary>
+        /// <param name="targetObject">The target object to check.</param>
+        /// <returns>Whether the change handler can be applied.</returns>
+        protected virtual bool CanApplyChangeHandlers(Object targetObject)
+        {
+            return Application.isPlaying && targetObject is Behaviour behaviour && behaviour.isActiveAndEnabled;
+        }
+
+        /// <summary>
+        /// Attempts to apply any found change handlers to the given property for the target object.
+        /// </summary>
+        /// <param name="targetObject">The target object to apply on.</param>
+        /// <param name="property">The property to apply the change handlers for.</param>
+        /// <returns>Whether the change handler was successfully applied to the property.</returns>
+        protected virtual bool TryApplyChangeHandlersToProperty(Object targetObject, SerializedProperty property)
+        {
+            // At design time we need to still allow Unity to persist the change and enable undo.
+            if (!CanApplyChangeHandlers(targetObject))
+            {
+                ApplyModifiedProperty(property, false);
+                return false;
+            }
+
+            ApplyChangeHandlersToProperty(targetObject, property);
+            return true;
+        }
+
+        /// <summary>
+        /// Applies any found change handlers to the given property.
+        /// </summary>
+        /// <param name="targetObject">The target object to apply on.</param>
+        /// <param name="property">The property to apply the change handlers for.</param>
+        protected virtual void ApplyChangeHandlersToProperty(Object targetObject, SerializedProperty property)
+        {
+            FindChangeHandlerMethods(property);
+
+            // There are change handlers. Run them manually and ensure Unity knows those change handlers did some changes (to persist them and enable undo for them).
+            if (ChangeHandlerMethodInfos.Count > 0)
+            {
+                Undo.RecordObject(targetObject, "Before change handlers");
+                BeforeChange(property);
+                Undo.FlushUndoRecordObjects();
+
+                using (SerializedObject serializedObjectCopy =
+                    new SerializedObject(property.serializedObject.targetObject))
+                {
+                    SerializedProperty propertyCopy = serializedObjectCopy.GetIterator();
+                    if (propertyCopy.Next(true))
+                    {
+                        do
+                        {
+                            if (propertyCopy.propertyPath != property.propertyPath)
+                            {
+                                property.serializedObject.CopyFromSerializedProperty(propertyCopy);
+                            }
+                        }
+                        while (propertyCopy.Next(false));
+                    }
+                }
+
+                ApplyModifiedProperty(property, true);
+                AfterChange(property);
+            }
+            // Ensure subclasses of this inspector can run before/after change logic. Also ensure Unity persists the change (including undo support).
+            else
+            {
+                BeforeChange(property);
+                ApplyModifiedProperty(property, false);
+                AfterChange(property);
+            }
+        }
+
+        /// <summary>
+        /// Processes the properties on the given <see cref="SerializedProperty"/> collection.
+        /// </summary>
+        /// <param name="property">A collection of properties to process.</param>
+        protected virtual void ProcessObjectProperties(SerializedProperty property)
+        {
+            string undoRedoWarningPropertyPath = UndoRedoWarningPropertyPath;
+
+            do
+            {
+                string propertyPath = property.propertyPath;
+                Object targetObject = property.serializedObject.targetObject;
+
+                using (EditorGUI.ChangeCheckScope changeCheckScope = new EditorGUI.ChangeCheckScope())
+                using (new EditorGUI.DisabledGroupScope(propertyPath == ScriptProperty))
+                {
+                    bool showUndoRedoWarning = CanShowUndoRedoWarning(propertyPath, undoRedoWarningPropertyPath);
+                    BeginDrawWarningMessage(showUndoRedoWarning);
+                    DrawProperty(property);
+                    EndDrawWarningMessage(showUndoRedoWarning);
+
+                    // No change has been done, nothing to do.
+                    if (!changeCheckScope.changed)
+                    {
+                        continue;
+                    }
+
+                    TryApplyChangeHandlersToProperty(targetObject, property);
+                }
+            }
+            while (property.NextVisible(false));
+        }
+
+        /// <summary>
+        /// Initiates the drawing the Undo/Redo warning.
+        /// </summary>
+        /// <param name="show">Whether to show the warning.</param>
+        protected virtual void BeginDrawWarningMessage(bool show)
+        {
+            if (show)
+            {
+                EditorGUILayout.BeginVertical(GUI.skin.box);
+                EditorGUILayout.HelpBox(UndoRedoWarningMessage, MessageType.Warning);
+                EditorGUI.indentLevel++;
+            }
+        }
+
+        /// <summary>
+        /// Concludes the drawing the Undo/Redo warning.
+        /// </summary>
+        /// <param name="show">Whether to show the warning.</param>
+        protected virtual void EndDrawWarningMessage(bool show)
+        {
+            if (show)
+            {
+                EditorGUILayout.EndVertical();
+                EditorGUI.indentLevel--;
+            }
         }
     }
 }


### PR DESCRIPTION
The custom unity InspectorEditor has now been refactored so the logic
within the OnInspectorGUI has been separated out into more logical
chunks so these different methods can be called separately or overriden
where required.

The functionality of the inspector has not changed in anyway so this
fix is purely just making method logic more accessible.