### PR TITLE
fix(deps): use latest pipeline templates

### DIFF
--- a/.devops/azure-pipelines.yml
+++ b/.devops/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: ExtendRealityLtd/DevOps
-      ref: refs/tags/v3.12.1
+      ref: refs/tags/v3.12.2
       endpoint: ExtendRealityLtd
 
 variables:


### PR DESCRIPTION
The latest pipeline template will attempt to force set a Unity version
if one is not provided to ensure Unity can be installed.