### PR TITLE
Use RequestScriptReload

### DIFF
--- a/Sources/FodyRunner.UnityIntegration/EditorWeaver.cs
+++ b/Sources/FodyRunner.UnityIntegration/EditorWeaver.cs
@@ -1,6 +1,7 @@
 ﻿namespace Malimbe.FodyRunner.UnityIntegration
 {
     using System;
+    using Reflection = System.Reflection;
     using System.Collections.Generic;
     using System.Linq;
     using JetBrains.Annotations;
@@ -51,6 +52,11 @@
                 if (didChangeAnyAssembly)
                 {
                     AssetDatabase.Refresh();
+                    Reflection.MethodInfo checkMethod = typeof(EditorUtility).GetMethod("RequestScriptReload", Reflection.BindingFlags.Public | Reflection.BindingFlags.Static);
+                    if (checkMethod != null)
+                    {
+                        checkMethod.Invoke(null, null);
+                    }
                 }
             }
         }


### PR DESCRIPTION
WeaveAllAssemblies() currently depends on the ordering of pre-compiled assembly loading / vs. assets loading.
Built assemblies (aside from the pre-defined assemblies) are actually not tracked by ADB. So if the Weaver integration dll is loaded after everything has been imported (and after the project has been compiled a first time) - which is the case with Unity 2020.3+, AssetDatabase.Refresh() won't do anything.