### PR TITLE
Update Fody to 6.6.3 and Bug fix

### DIFF
--- a/Sources/BehaviourStateRequirementMethod.Fody/BehaviourStateRequirementMethod.Fody.csproj
+++ b/Sources/BehaviourStateRequirementMethod.Fody/BehaviourStateRequirementMethod.Fody.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/BehaviourStateRequirementMethod.Fody/ModuleWeaver.cs
+++ b/Sources/BehaviourStateRequirementMethod.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.BehaviourStateRequirementMethod.Fody
+namespace Malimbe.BehaviourStateRequirementMethod.Fody
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -42,7 +42,7 @@
 
                 if (gameObjectActivity == GameObjectActivity.None && !behaviourNeedsToBeEnabled)
                 {
-                    LogWarning(
+                    WriteWarning(
                         $"The method '{methodDefinition.FullName}' is annotated to require a Behaviour state"
                         + " but the attribute constructor arguments result in no action being taken.");
                     continue;
@@ -52,7 +52,7 @@
                 Collection<Instruction> instructions = body.Instructions;
                 if (instructions.Count == 0)
                 {
-                    LogWarning(
+                    WriteWarning(
                         $"The method '{methodDefinition.FullName}' is annotated to require a Behaviour state"
                         + " but the method has no instructions in its body and thus no action is being taken.");
                     continue;
@@ -80,11 +80,11 @@
                 ModuleDefinition.ImportReference(
                     typeDefinition.Properties.Single(definition => definition.Name == propertyName).GetMethod);
 
-            TypeDefinition behaviourTypeDefinition = FindType("UnityEngine.Behaviour");
-            TypeDefinition gameObjectTypeDefinition = FindType("UnityEngine.GameObject");
+            TypeDefinition behaviourTypeDefinition = FindTypeDefinition("UnityEngine.Behaviour");
+            TypeDefinition gameObjectTypeDefinition = FindTypeDefinition("UnityEngine.GameObject");
 
             _behaviourTypeReference = ModuleDefinition.ImportReference(behaviourTypeDefinition);
-            _getGameObjectMethodReference = ImportPropertyGetter(FindType("UnityEngine.Component"), "gameObject");
+            _getGameObjectMethodReference = ImportPropertyGetter(FindTypeDefinition("UnityEngine.Component"), "gameObject");
             _getActiveSelfMethodReference = ImportPropertyGetter(gameObjectTypeDefinition, "activeSelf");
             _getActiveInHierarchyMethodReference = ImportPropertyGetter(gameObjectTypeDefinition, "activeInHierarchy");
             _getIsActiveAndEnabledMethodReference =
@@ -102,14 +102,14 @@
             }
 
             methodDefinition.CustomAttributes.Remove(foundAttribute);
-            LogInfo($"Removed the attribute '{_fullAttributeName}' from the method '{methodDefinition.FullName}'.");
+            WriteInfo($"Removed the attribute '{_fullAttributeName}' from the method '{methodDefinition.FullName}'.");
 
             if (methodDefinition.DeclaringType.IsSubclassOf(_behaviourTypeReference))
             {
                 return true;
             }
 
-            LogError(
+            WriteError(
                 $"The method '{methodDefinition.FullName}' is annotated to require a Behaviour state"
                 + $" but the declaring type doesn't derive from '{_behaviourTypeReference.FullName}'.");
             return false;
@@ -184,7 +184,7 @@
                 }
             }
 
-            LogInfo($"Added (an) early return(s) to the method '{methodDefinition.FullName}'.");
+            WriteInfo($"Added (an) early return(s) to the method '{methodDefinition.FullName}'.");
         }
 
         private static void AddEarlyReturnInstruction(

--- a/Sources/FodyRunner.UnityIntegration/EditorWeaver.cs
+++ b/Sources/FodyRunner.UnityIntegration/EditorWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.FodyRunner.UnityIntegration
+namespace Malimbe.FodyRunner.UnityIntegration
 {
     using System;
     using Reflection = System.Reflection;
@@ -14,14 +14,19 @@
         [InitializeOnLoadMethod]
         private static void OnEditorInitialization()
         {
+#if !UNITY_2021_1_OR_NEWER
             CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
+#endif
             WeaveAllAssemblies();
         }
 
         private static void WeaveAllAssemblies()
         {
             EditorApplication.LockReloadAssemblies();
+
+#if !UNITY_2021_1_OR_NEWER
             bool didChangeAnyAssembly = false;
+#endif
 
             try
             {
@@ -42,13 +47,17 @@
                         continue;
                     }
 
+#if !UNITY_2021_1_OR_NEWER
                     AssetDatabase.ImportAsset(sourceFilePath, ImportAssetOptions.ForceUpdate);
                     didChangeAnyAssembly = true;
+#endif
                 }
             }
             finally
             {
                 EditorApplication.UnlockReloadAssemblies();
+
+#if !UNITY_2021_1_OR_NEWER
                 if (didChangeAnyAssembly)
                 {
                     AssetDatabase.Refresh();
@@ -58,9 +67,11 @@
                         checkMethod.Invoke(null, null);
                     }
                 }
+#endif
             }
         }
 
+#if !UNITY_2021_1_OR_NEWER
         private static void OnCompilationFinished(string path, CompilerMessage[] messages)
         {
             Assembly foundAssembly = GetAllAssemblies()
@@ -76,6 +87,7 @@
 
             WeaveAssembly(foundAssembly, runner);
         }
+#endif
 
         [NotNull]
         private static IEnumerable<Assembly> GetAllAssemblies() =>

--- a/Sources/FodyRunner.UnityIntegration/FodyRunner.UnityIntegration.csproj
+++ b/Sources/FodyRunner.UnityIntegration/FodyRunner.UnityIntegration.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Malimbe.FodyRunner.UnityIntegration</AssemblyName>
     <RootNamespace>Malimbe.FodyRunner.UnityIntegration</RootNamespace>
     <LangVersion>latest</LangVersion>
-    <UnityEditorAssembliesPath Condition="'$(UnityEditorAssembliesPath)' == ''">C:\Program Files\Unity\Hub\Editor\2018.3.10f1\Editor\Data\Managed</UnityEditorAssembliesPath>
+    <UnityEditorAssembliesPath Condition="'$(UnityEditorAssembliesPath)' == ''">D:\Program Files\Unity\2021.3.1f1\Editor\Data\Managed</UnityEditorAssembliesPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/FodyRunner/FodyRunner.csproj
+++ b/Sources/FodyRunner/FodyRunner.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fody" Version="3.3.5">
+    <PackageReference Include="Fody" Version="6.6.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Sources/FodyRunner/Runner.cs
+++ b/Sources/FodyRunner/Runner.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.FodyRunner
+namespace Malimbe.FodyRunner
 {
     using System.Collections.Generic;
     using System.IO;
@@ -67,7 +67,7 @@
                     continue;
                 }
 
-                WeaverEntry existingEntry = _weaverEntries.FirstOrDefault(entry => entry.AssemblyName == assemblyName);
+                WeaverEntry existingEntry = _weaverEntries.FirstOrDefault(entry => entry.ElementName == assemblyName);
                 int index = _weaverEntries.Count;
                 if (existingEntry != null)
                 {
@@ -80,9 +80,7 @@
                 WeaverEntry weaverEntry = new WeaverEntry
                 {
                     Element = weaverElement.ToString(SaveOptions.OmitDuplicateNamespaces),
-                    AssemblyName = assemblyName,
                     AssemblyPath = assemblyPath,
-                    TypeName = "ModuleWeaver"
                 };
                 _weaverEntries.Insert(index, weaverEntry);
             }
@@ -118,7 +116,7 @@
             return Task.Run(
                 () =>
                 {
-                    string assemblyFileName = Path.GetFileNameWithoutExtension(assemblyFilePath);
+                    string assemblyFileName = Path.GetFileName(assemblyFilePath);
                     if (assemblyFileName != null
                         && _assemblyRegexes.TrueForAll(regex => !regex.IsMatch(assemblyFileName)))
                     {
@@ -146,11 +144,20 @@
                     {
                         AssemblyFilePath = assemblyFilePath,
                         References = string.Join(";", references),
+
+                        KeyFilePath = string.Empty,
                         ReferenceCopyLocalPaths = new List<string>(),
-                        DefineConstants = defineConstants,
+                        RuntimeCopyLocalPaths = new List<string>(),
+                        SignAssembly = false,
+                        DelaySign = false,
                         Logger = _logForwarder,
+                        SolutionDirectoryPath = string.Empty,
                         Weavers = _weaverEntries,
-                        DebugSymbols = isDebugBuild ? DebugSymbolsType.External : DebugSymbolsType.None
+                        IntermediateDirectoryPath = string.Empty,
+                        DefineConstants = defineConstants,
+                        ProjectDirectoryPath = string.Empty,
+                        ProjectFilePath = string.Empty,
+                        DocumentationFilePath = string.Empty,
                     };
                     CancellationTokenRegistration cancellationTokenRegistration =
                         // ReSharper disable once AccessToDisposedClosure

--- a/Sources/MemberChangeMethod.Fody/MemberChangeMethod.Fody.csproj
+++ b/Sources/MemberChangeMethod.Fody/MemberChangeMethod.Fody.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/MemberChangeMethod.Fody/ModuleWeaver.cs
+++ b/Sources/MemberChangeMethod.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.MemberChangeMethod.Fody
+namespace Malimbe.MemberChangeMethod.Fody
 {
     using System;
     using System.Collections.Generic;
@@ -43,7 +43,7 @@
 
                     if (propertyDefinition.SetMethod == null)
                     {
-                        LogError(
+                        WriteError(
                             $"The method '{methodDefinition.FullName}' is annotated to be called by the setter of the"
                             + $" property '{propertyDefinition.FullName}' but the property has no setter.");
                         continue;
@@ -64,14 +64,14 @@
         {
             MethodReference ImportPropertyGetter(string typeName, string propertyName) =>
                 ModuleDefinition.ImportReference(
-                    FindType(typeName).Properties.Single(definition => definition.Name == propertyName).GetMethod);
+                    FindTypeDefinition(typeName).Properties.Single(definition => definition.Name == propertyName).GetMethod);
 
             _isApplicationPlayingGetterReference = ImportPropertyGetter("UnityEngine.Application", "isPlaying");
             _isActiveAndEnabledGetterReference = ImportPropertyGetter("UnityEngine.Behaviour", "isActiveAndEnabled");
             _compilerGeneratedAttributeConstructorReference = ModuleDefinition.ImportReference(
-                FindType("System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                FindTypeDefinition("System.Runtime.CompilerServices.CompilerGeneratedAttribute")
                     .Methods.First(definition => definition.IsConstructor));
-            _behaviourReference = ModuleDefinition.ImportReference(FindType("UnityEngine.Behaviour"));
+            _behaviourReference = ModuleDefinition.ImportReference(FindTypeDefinition("UnityEngine.Behaviour"));
             _isCompilingForEditor = DefineConstants.Contains("UNITY_EDITOR");
         }
 
@@ -103,7 +103,7 @@
 
             if (propertyDefinition == null)
             {
-                LogError(
+                WriteError(
                     $"The method '{methodDefinition.FullName}' is annotated to be called by the setter of the"
                     + $" property '{propertyName}' but the property doesn't exist.");
                 return false;
@@ -115,7 +115,7 @@
                 return true;
             }
 
-            LogError(
+            WriteError(
                 $"The method '{methodDefinition.FullName}' is annotated to be called by the setter of the"
                 + $" property '{propertyName}' but the method signature doesn't match. The expected signature is"
                 + $" 'void {methodDefinition.Name}()'.");
@@ -145,7 +145,7 @@
                 setterCallInstruction.OpCode = OpCodes.Stfld;
                 setterCallInstruction.Operand = backingField;
 
-                LogInfo(
+                WriteInfo(
                     $"Changed the property setter call in '{methodDefinition.FullName}' to set the backing"
                     + $" field '{backingField.FullName}' instead to prevent a potential infinite loop.");
             }
@@ -334,7 +334,7 @@
                         methodDefinition.IsReuseSlot = true;
                         methodDefinition.IsHideBySig = true;
 
-                        LogInfo(
+                        WriteInfo(
                             $"Changed the method '{methodDefinition.FullName}' to override the"
                             + $" newly added base method '{baseMethodDefinition.FullName}'.");
                     }
@@ -351,7 +351,7 @@
 
                 methodBody.OptimizeMacros();
 
-                LogInfo(
+                WriteInfo(
                     $"Inserted a call to the method '{methodReference.FullName}' into"
                     + $" the setter of the property '{propertyDefinition.FullName}'.");
             }

--- a/Sources/MemberClearanceMethod.Fody/MemberClearanceMethod.Fody.csproj
+++ b/Sources/MemberClearanceMethod.Fody/MemberClearanceMethod.Fody.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/MemberClearanceMethod.Fody/ModuleWeaver.cs
+++ b/Sources/MemberClearanceMethod.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.MemberClearanceMethod.Fody
+namespace Malimbe.MemberClearanceMethod.Fody
 {
     using System;
     using System.Collections.Generic;
@@ -43,7 +43,7 @@
                     case PropertyDefinition propertyDefinition:
                         if (propertyDefinition.SetMethod == null)
                         {
-                            LogError(
+                            WriteError(
                                 $"The property '{propertyDefinition.FullName}' is annotated"
                                 + " to be cleared but has no setter.");
                         }
@@ -65,7 +65,7 @@
 
                 if (typeReference.IsPrimitive || typeReference.IsValueType)
                 {
-                    LogError(
+                    WriteError(
                         $"The member '{memberDefinition.FullName}' is annotated to be cleared"
                         + $" but its type '{typeReference.FullName}' isn't of reference type.");
                     continue;
@@ -77,7 +77,7 @@
                 MethodDefinition clearMethodDefinition = FindClearMethod(memberDefinition, methodName);
                 if (clearMethodDefinition != null)
                 {
-                    LogInfo(
+                    WriteInfo(
                         $"The clear method '{clearMethodDefinition.FullName}' already exists. A setter call"
                         + $" to clear the member '{memberDefinition.FullName}' will be inserted nonetheless."
                         + " The clearing will be done at the end of the existing method.");
@@ -108,7 +108,7 @@
 
         private void FindReferences() =>
             _compilerGeneratedAttributeConstructorReference = ModuleDefinition.ImportReference(
-                FindType("System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                FindTypeDefinition("System.Runtime.CompilerServices.CompilerGeneratedAttribute")
                     .Methods.First(definition => definition.IsConstructor));
 
         private bool FindAndRemoveAttribute(IMemberDefinition memberDefinition)
@@ -121,7 +121,7 @@
             }
 
             memberDefinition.CustomAttributes.Remove(foundAttribute);
-            LogInfo($"Removed the attribute '{_fullAttributeName}' from the member '{memberDefinition.FullName}'.");
+            WriteInfo($"Removed the attribute '{_fullAttributeName}' from the member '{memberDefinition.FullName}'.");
             return true;
         }
 
@@ -166,7 +166,7 @@
                 ++index,
                 Instruction.Create(OpCodes.Callvirt, propertyDefinition.SetMethod.CreateGenericMethodIfNeeded()));
 
-            LogInfo(
+            WriteInfo(
                 $"Inserted a setter call to clear the property '{propertyDefinition.FullName}'"
                 + $" into the method '{methodDefinition.FullName}'.");
         }
@@ -185,7 +185,7 @@
             // Store into field
             instructions.Insert(++index, Instruction.Create(OpCodes.Stfld, fieldReference));
 
-            LogInfo(
+            WriteInfo(
                 $"Inserted a setter call to clear the field '{fieldReference.FullName}'"
                 + $" into the method '{methodDefinition.FullName}'.");
         }

--- a/Sources/PropertySerializationAttribute.Fody/ModuleWeaver.cs
+++ b/Sources/PropertySerializationAttribute.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.PropertySerializationAttribute.Fody
+namespace Malimbe.PropertySerializationAttribute.Fody
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -34,14 +34,14 @@
                 FieldReference backingFieldReference = propertyDefinition.FindBackingField();
                 if (backingFieldReference == null)
                 {
-                    LogError(
+                    WriteError(
                         $"No backing field for the property '{propertyDefinition.FullName}' was found."
                         + " A field is assumed to be backing the property if the property getter loads"
                         + " the field and the setter stores into that same field.");
                     continue;
                 }
 
-                LogInfo(
+                WriteInfo(
                     $"Assuming the field '{backingFieldReference.FullName}' is the backing field for"
                     + $" the property '{propertyDefinition.FullName}'.");
 
@@ -56,7 +56,7 @@
 
         private void FindReferences() =>
             _serializeFieldAttributeConstructorReference = ModuleDefinition.ImportReference(
-                FindType("UnityEngine.SerializeField").Methods.First(definition => definition.IsConstructor));
+                FindTypeDefinition("UnityEngine.SerializeField").Methods.First(definition => definition.IsConstructor));
 
         private bool FindAndRemoveAttribute(IMemberDefinition propertyDefinition)
         {
@@ -68,7 +68,7 @@
             }
 
             propertyDefinition.CustomAttributes.Remove(foundAttribute);
-            LogInfo(
+            WriteInfo(
                 $"Removed the attribute '{_fullAttributeName}' from"
                 + $" the property '{propertyDefinition.FullName}'.");
             return true;
@@ -84,7 +84,7 @@
                 customAttribute => customAttribute.Constructor != _serializeFieldAttributeConstructorReference))
             {
                 customAttributes.Add(new CustomAttribute(_serializeFieldAttributeConstructorReference));
-                LogInfo(
+                WriteInfo(
                     $"Added the attribute '{_serializeFieldAttributeConstructorReference.DeclaringType.FullName}'"
                     + $" to the field '{backingFieldReference.FullName}'.");
             }
@@ -115,7 +115,7 @@
             }
 
             backingFieldDefinition.Name = newFieldName;
-            LogInfo($"Changed the name of the field '{previousFieldName}' to '{newFieldName}'.");
+            WriteInfo($"Changed the name of the field '{previousFieldName}' to '{newFieldName}'.");
         }
     }
 }

--- a/Sources/PropertySerializationAttribute.Fody/PropertySerializationAttribute.Fody.csproj
+++ b/Sources/PropertySerializationAttribute.Fody/PropertySerializationAttribute.Fody.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Shared/Shared.csproj
+++ b/Sources/Shared/Shared.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
 </Project>

--- a/Sources/XmlDocumentationAttribute.Fody/ModuleWeaver.cs
+++ b/Sources/XmlDocumentationAttribute.Fody/ModuleWeaver.cs
@@ -1,4 +1,4 @@
-﻿namespace Malimbe.XmlDocumentationAttribute.Fody
+namespace Malimbe.XmlDocumentationAttribute.Fody
 {
     using System;
     using System.Collections.Generic;
@@ -64,7 +64,7 @@
 
                     if (summaries == null)
                     {
-                        LogError(
+                        WriteError(
                             $"The field '{fieldDefinition.FullName}' is annotated to be documented by XML"
                             + " documentation comments but none were found.");
                         continue;
@@ -72,7 +72,7 @@
 
                     if (summaries.Count > 1)
                     {
-                        LogError(
+                        WriteError(
                             $"There are at least two identifiers called '{fieldDefinition.Name}' in '{lookupTypeDefinition.FullName}'."
                             + " Only a single identifier name per source code file is currently supported. The first occurrence of"
                             + $" the identifier name will be annotated using the attribute '{_attributeDefinition.FullName}'.");
@@ -91,7 +91,7 @@
         private void FindReferences()
         {
             string typeName = Config?.Attribute("FullAttributeName")?.Value ?? "UnityEngine.TooltipAttribute";
-            TypeDefinition typeDefinition = FindType(typeName);
+            TypeDefinition typeDefinition = FindTypeDefinition(typeName);
             if (typeDefinition == null)
             {
                 throw new WeavingException($"No attribute with the name '{typeName}' was found.");
@@ -117,14 +117,14 @@
             string identifierReplacementFormat = Config.Attribute(IdentifierReplacementFormatElementName)?.Value;
             if (string.IsNullOrWhiteSpace(identifierReplacementFormat))
             {
-                LogInfo(
+                WriteInfo(
                     $"No '{IdentifierReplacementFormatElementName}' element is specified in the configuration."
                     + $" Falling back to use '{DefaultIdentifierReplacementFormat}'.");
                 identifierReplacementFormat = DefaultIdentifierReplacementFormat;
             }
             else if (!identifierReplacementFormat.Contains("{0}"))
             {
-                LogError(
+                WriteError(
                     $"The '{IdentifierReplacementFormatElementName}' configuration element doesn't specify a format"
                     + $" placeholder '{{0}}'. Falling back to use '{DefaultIdentifierReplacementFormat}'.");
                 identifierReplacementFormat = DefaultIdentifierReplacementFormat;
@@ -143,7 +143,7 @@
             }
 
             fieldDefinition.CustomAttributes.Remove(foundAttribute);
-            LogInfo($"Removed the attribute '{_fullAttributeName}' from the field '{fieldDefinition.FullName}'.");
+            WriteInfo($"Removed the attribute '{_fullAttributeName}' from the field '{fieldDefinition.FullName}'.");
             return true;
         }
 
@@ -151,7 +151,7 @@
             TypeDefinition typeDefinition,
             string identifierReplacementFormat)
         {
-            string GetDocumentFilePath(TypeDefinition definition) =>
+            static string GetDocumentFilePath(TypeDefinition definition) =>
                 definition.Methods.Select(methodDefinition => methodDefinition.DebugInformation)
                     .SelectMany(information => information.SequencePoints)
                     .FirstOrDefault()
@@ -243,7 +243,7 @@
             bool didAttributeAlreadyExist = existingAttribute != null;
             if (didAttributeAlreadyExist)
             {
-                LogWarning(
+                WriteWarning(
                     $"The field '{fieldDefinition.FullName}' is documented using XML documentation comments"
                     + $" but already uses the attribute '{_attributeDefinition.FullName}'."
                     + " The attribute is replaced.");
@@ -259,7 +259,7 @@
             };
             fieldDefinition.CustomAttributes.Add(newAttribute);
 
-            LogInfo(
+            WriteInfo(
                 $"{(didAttributeAlreadyExist ? "Updated" : "Added")} the attribute"
                 + $" '{_attributeDefinition.FullName}' for the field '{fieldDefinition.FullName}'"
                 + " using the field's XML documentation comments.");

--- a/Sources/XmlDocumentationAttribute.Fody/XmlDocumentationAttribute.Fody.csproj
+++ b/Sources/XmlDocumentationAttribute.Fody/XmlDocumentationAttribute.Fody.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FodyHelpers" Version="3.3.5" />
+    <PackageReference Include="FodyHelpers" Version="6.6.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1 Upgrade Fody to 6.6.3 
2 Fix Reload case load infinite times on Unity2021 
3 Use Assembly FileName With Extensions So that it can match Better for dlls like Assembly-CSharp.dll and Assembly-CSharp-Editor.dll